### PR TITLE
Base url

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+# Overview
+
+
+
+## Changes
+
+
+
+## Justification
+
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,40 +8,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        continue-on-error: true  # WARNING: only for this example, remove it!
-        with:
-          command: check
+      - name: Run tests
+        run: cargo check
 
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        continue-on-error: true  # WARNING: only for this example, remove it!
-        with:
-          command: test
+      - name: Run tests
+        run: cargo test
 
   lints:
     name: Lints
@@ -50,24 +30,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
+      - name: Rust Format 
+        run: cargo fmt --all -- --check
 
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        continue-on-error: true  # WARNING: only for this example, remove it!
-        with:
-          command: fmt
-          args: --all -- --check
-
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        continue-on-error: true  # WARNING: only for this example, remove it!
-        with:
-          command: clippy
-          args: -- -D warnings
+      - name: Clippy
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Rust Format 
         run: cargo fmt --all -- --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,73 @@
+on: [push, pull_request]
+
+name: Tests
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        continue-on-error: true  # WARNING: only for this example, remove it!
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        continue-on-error: true  # WARNING: only for this example, remove it!
+        with:
+          command: test
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        continue-on-error: true  # WARNING: only for this example, remove it!
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        continue-on-error: true  # WARNING: only for this example, remove it!
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "markdown",
  "nanoid",
  "pathdiff",
+ "relative-path",
  "rust-embed",
  "serde",
  "serde_yaml",
@@ -557,6 +558,15 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "relative-path"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "rle-decode-fast"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ tree-sitter-bash = "0.20.3"
 
 # SERVER
 tiny_http = "0.12.0"
+relative-path = { version = "1.9.2", features=["serde"] } 
 
 
 [profile.release]

--- a/assets/static/css/article.css
+++ b/assets/static/css/article.css
@@ -4,12 +4,6 @@ body {
   font-size: 15px;
 }
 
-@font-face {
-  font-family: 'Overpass';
-  src: url('/webfonts/overpass.ttf') format("truetype-variations");
-  font-weight: 1 999;
-}
-
 .container {
   margin-left: 0!important;
   margin-right: 0!important;

--- a/assets/templates/404.html
+++ b/assets/templates/404.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <title>Oops. Page Not Found</title>
-      <link rel="stylesheet" href="/css/bootstrap.min.css">
-      <link rel="stylesheet" href="/css/article.css">
+    <link rel="stylesheet" href="{{project.base_url}}css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{project.base_url}}css/article.css">
   </head>
   <body>
       <div class="border bottom-border p-3 fixed-top bg-white text-secondary">

--- a/assets/templates/article.html
+++ b/assets/templates/article.html
@@ -1,11 +1,11 @@
 <html>
   <head>
     <title>{{project.name}} | {{document.title}}</title>
-    <link rel="stylesheet" href="{{project.base_url}}/css/fa.min.css">
-    <link rel="stylesheet" href="{{project.base_url}}/js/fa.min.js">
-    <link rel="stylesheet" href="{{project.base_url}}/css/bootstrap.min.css">
-    <link rel="stylesheet" href="{{project.base_url}}/css/article.css">
-    <script src="{{project.base_url}}/js/bootstrap.bundle.min.js" ></script>
+    <link rel="stylesheet" href="{{project.base_url}}css/fa.min.css">
+    <link rel="stylesheet" href="{{project.base_url}}js/fa.min.js">
+    <link rel="stylesheet" href="{{project.base_url}}css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{project.base_url}}css/article.css">
+    <script src="{{project.base_url}}js/bootstrap.bundle.min.js" ></script>
   <style>
     @font-face {
       font-family: 'Overpass';

--- a/assets/templates/article.html
+++ b/assets/templates/article.html
@@ -1,11 +1,18 @@
 <html>
   <head>
     <title>{{project.name}} | {{document.title}}</title>
-    <link rel="stylesheet" href="/css/fa.min.css">
-    <link rel="stylesheet" href="/js/fa.min.js">
-    <link rel="stylesheet" href="/css/bootstrap.min.css">
-    <link rel="stylesheet" href="/css/article.css">
-    <script src="/js/bootstrap.bundle.min.js" ></script>
+    <link rel="stylesheet" href="{{project.base_url}}/css/fa.min.css">
+    <link rel="stylesheet" href="{{project.base_url}}/js/fa.min.js">
+    <link rel="stylesheet" href="{{project.base_url}}/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{project.base_url}}/css/article.css">
+    <script src="{{project.base_url}}/js/bootstrap.bundle.min.js" ></script>
+  <style>
+    @font-face {
+      font-family: 'Overpass';
+      src: url('{{project.base_url}}/webfonts/overpass.ttf') format("truetype-variations");
+      font-weight: 1 999;
+    }
+  </style>
   </head>
   <body
       data-bs-spy="scroll" 
@@ -48,7 +55,7 @@
               {{#each sitemap.pages}}
                 {{#if this.frontmatter.title}}
                 <a class="text-nowrap pe-3 fs-6 fw-light text-capitalie d-block link-underline-opacity-0 link-dark link-underline-opacity-75-hover" 
-                  href="{{this.url}}">{{this.frontmatter.title}}</a>
+                   href="{{this.url}}">{{this.frontmatter.title}}</a>
                 {{/if}}
               {{/each}}
               </div>
@@ -57,7 +64,7 @@
                 <div class="text-capitalize fw-bold fs-7">{{this.name}}</div>
                 {{#each this.pages}}
                   <a class="text-nowrap pe-3 fs-6 fw-light text-capitalie d-block link-underline-opacity-0 link-dark link-underline-opacity-75-hover" 
-                    href="{{this.url}}">{{this.frontmatter.title}}</a>
+                   href="{{this.url}}">{{this.frontmatter.title}}</a>
                 {{/each}}
               </div>
             {{/each}}

--- a/docs/codex.yml
+++ b/docs/codex.yml
@@ -1,3 +1,4 @@
 name: Codex Documentation Manager
 repo_url: https://git.5sigma.io/codex/codex
 project_page: https://codex.5sigma.io
+base_url: /docs/dist

--- a/src/core/document.rs
+++ b/src/core/document.rs
@@ -8,7 +8,12 @@ use markdown::{
 use serde::{Deserialize, Serialize};
 use tree_sitter_highlight::{HighlightConfiguration, HighlightEvent, Highlighter};
 
-use crate::{render_template, Result};
+use crate::{render_template, Project, Result};
+
+pub enum ContentMode {
+    Server,
+    Build,
+}
 
 /// The names of the classes for syntax highlighting
 /// This is used to highlight code blocks
@@ -70,6 +75,8 @@ pub struct Document {
     pub toc: Vec<TocEntry>,
     /// The URL of the document
     pub url: String,
+    /// The URL of the document
+    pub base_url: String,
 }
 
 impl std::fmt::Debug for Document {
@@ -100,7 +107,7 @@ impl Document {
     /// ```
     /// # See Also
     /// * [`Document::parse_file`] - Parse a markdown file into a document
-    pub fn parse(file_path: PathBuf, content: &str) -> Result<Self> {
+    pub fn parse(project: &Project, file_path: PathBuf, content: &str) -> Result<Self> {
         let parser_options = markdown::ParseOptions {
             constructs: markdown::Constructs {
                 code_indented: false,
@@ -143,16 +150,18 @@ impl Document {
             })
             .unwrap_or_default();
 
-        // Convert the AST to HTML
-        let body = to_html(&ast);
-
-        Ok(Document {
+        let mut doc = Document {
             frontmatter,
-            body,
+            body: "".to_string(),
             toc,
             url: file_path.display().to_string(),
+            base_url: project.details.base_url.clone(),
             file_path,
-        })
+        };
+        // Convert the AST to HTML
+        doc.body = doc.to_html(&ast);
+
+        Ok(doc)
     }
 
     /// Parse a markdown file into a document
@@ -168,161 +177,202 @@ impl Document {
     /// use core::Document;
     /// let document = Document::parse_file("somefile.md").unwrap();
     /// ```
-    pub fn parse_file<P>(file_path: P) -> Result<Self>
+    pub fn parse_file<P>(project: &Project, file_path: P) -> Result<Self>
     where
         P: Into<PathBuf>,
     {
         let file_path = file_path.into();
         let content = std::fs::read_to_string(file_path.clone())?;
-        Self::parse(file_path, &content)
+        Self::parse(project, file_path, &content)
     }
 
     /// Get the HTML content of the page
-    pub fn page_content(&self, project: &crate::Project) -> Result<String> {
+    pub fn page_content(&self, project: &crate::Project, mode: ContentMode) -> Result<String> {
         let sitemap = (&project.root_folder).into();
         let data = DataContext {
             body: self.body.clone(),
             document: self.frontmatter.clone(),
             sitemap,
-            project: project.details.clone(),
+            project: match mode {
+                ContentMode::Server => project.serve_details(),
+                ContentMode::Build => project.build_details(),
+            },
             toc: self.toc.clone(),
         };
         render_template(data, &crate::assets::get_str("templates/article.html"))
+    }
+
+    /// Convert a single node to HTML
+    pub fn to_html(&self, node: &Node) -> String {
+        match node {
+            Node::Root(root) => root.children.iter().fold(String::new(), |acc, child| {
+                format!("{}{}", acc, self.to_html(child))
+            }),
+            Node::BlockQuote(block_quote) => self.wrap_nodes(
+                r#"<blockquote class="blockquote">"#,
+                "</blockquote>",
+                &block_quote.children,
+            ),
+            Node::FootnoteDefinition(_) => "".to_string(),
+            Node::MdxJsxFlowElement(el) => {
+                if let Some(name) = el.name.as_ref() {
+                    match self.apply_component(name, &el.attributes, &el.children) {
+                        Ok(html) => html,
+                        Err(e) => format!("<pre>{}</pre>", html_escape(&e.to_string())),
+                    }
+                } else {
+                    "".to_string()
+                }
+            }
+            Node::MdxJsxTextElement(el) => {
+                if let Some(name) = el.name.as_ref() {
+                    match self.apply_component(name, &el.attributes, &el.children) {
+                        Ok(html) => html,
+                        Err(e) => format!("<pre>{}</pre>", html_escape(&e.to_string())),
+                    }
+                } else {
+                    "".to_string()
+                }
+            }
+            Node::List(list) => {
+                if list.ordered {
+                    self.wrap_nodes("<ol>", "</ol>", &list.children)
+                } else {
+                    self.wrap_nodes("<ul>", "</ul>", &list.children)
+                }
+            }
+            Node::MdxjsEsm(_) => "".to_string(),
+            Node::Toml(_) => "".to_string(),
+            Node::Yaml(_) => "".to_string(),
+            Node::Break(_) => "".to_string(),
+            Node::InlineCode(_) => "".to_string(),
+            Node::InlineMath(_) => "".to_string(),
+            Node::Delete(_) => "".to_string(),
+            Node::Emphasis(em) => {
+                self.wrap_nodes(r#"<span class="fst-italic">"#, "</span>", &em.children)
+            }
+            Node::MdxTextExpression(_) => "".to_string(),
+            Node::FootnoteReference(_) => "".to_string(),
+            Node::Html(_) => "".to_string(),
+            Node::Image(_) => "".to_string(),
+            Node::ImageReference(_) => "".to_string(),
+            Node::Link(link) => {
+                format!(
+                    "<a href=\"{}{}\">{}</a>",
+                    self.base_url,
+                    link.url.clone(),
+                    self.all_to_html(link.children.as_slice())
+                )
+            }
+            Node::LinkReference(_) => "".to_string(),
+            Node::Strong(bold) => {
+                self.wrap_nodes(r#"<span class="fw-bold">"#, "</span>", &bold.children)
+            }
+            Node::Text(text) => text.value.clone(),
+            Node::Code(code) => {
+                let mut s = String::from("<pre><code>");
+                if let Some(config) = code
+                    .lang
+                    .as_ref()
+                    .and_then(|lang| build_highlighter_config(lang))
+                {
+                    let mut highlighter = Highlighter::new();
+                    let highlights = highlighter
+                        .highlight(&config, code.value.as_bytes(), None, |_| None)
+                        .unwrap();
+
+                    for event in highlights {
+                        match event.unwrap() {
+                            HighlightEvent::Source { start, end } => {
+                                s.push_str(&html_escape(&code.value[start..end]));
+                            }
+                            HighlightEvent::HighlightStart(highlight) => {
+                                s.push_str(&format!("<span class=\"highlight-{}\">", highlight.0));
+                            }
+                            HighlightEvent::HighlightEnd => {
+                                s.push_str("</span>");
+                            }
+                        }
+                    }
+                } else {
+                    s.push_str(&html_escape(&code.value));
+                }
+                s.push_str("</code></pre>");
+                s
+            }
+            Node::Math(_) => "".to_string(),
+            Node::MdxFlowExpression(exp) => self.apply_expression(&exp.value).unwrap(),
+            Node::Heading(h) => {
+                let text = heading_text(h).unwrap();
+                let slug = slug(&text);
+                let tag = format!("h{}", h.depth + 3);
+                let html = h.children.iter().fold(String::new(), |acc, child| {
+                    format!("{}{}", acc, self.to_html(child))
+                });
+                format!("<{} id=\"{}\">{}</{}>", tag, slug, html, tag)
+            }
+            Node::Table(table) => self.wrap_nodes(
+                "<table class=\"table table-sm\">",
+                "</table>",
+                &table.children,
+            ),
+            Node::ThematicBreak(_) => "<hr/>".to_string(),
+            Node::TableRow(node) => self.wrap_nodes("<tr>", "</tr>", &node.children),
+            Node::TableCell(node) => self.wrap_nodes("<td>", "</td>", &node.children),
+            Node::ListItem(li) => self.wrap_nodes("<li>", "</li>", &li.children),
+            Node::Definition(_) => "".to_string(),
+            Node::Paragraph(p) => self.wrap_nodes("<p>", "</p>", &p.children),
+        }
+    }
+
+    /// Wrap a list of nodes in HTML with the provided start and end fragments
+    pub fn wrap_nodes(&self, start: &str, end: &str, nodes: &[Node]) -> String {
+        format!("{}{}{}", start, self.all_to_html(nodes), end)
+    }
+
+    /// Convert a list of nodes to HTML
+    pub fn all_to_html(&self, nodes: &[Node]) -> String {
+        nodes.iter().fold(String::new(), |acc, child| {
+            format!("{}{}", acc, self.to_html(child))
+        })
+    }
+
+    pub fn apply_component(
+        &self,
+        name: &str,
+        attrs: &[markdown::mdast::AttributeContent],
+        children: &[Node],
+    ) -> Result<String> {
+        let template = match name {
+            "Alert" => crate::assets::get_str("components/alert.html"),
+            "Field" => crate::assets::get_str("components/field.html"),
+            _ => String::default(),
+        };
+
+        let mut data = HashMap::new();
+        for attr in attrs {
+            if let AttributeContent::Property(MdxJsxAttribute {
+                name,
+                value: Some(AttributeValue::Literal(value)),
+            }) = attr
+            {
+                data.insert(name.to_string(), value.to_string());
+            }
+        }
+        data.insert("children".to_string(), self.all_to_html(children));
+        render_template(data, &template)
+    }
+
+    pub fn apply_expression(&self, exp: &str) -> Result<String> {
+        match exp {
+            "id" => Ok(nanoid::nanoid!()),
+            _ => Ok("".to_string()),
+        }
     }
 }
 
 pub fn parse_expression(_value: &str, _kind: &MdxExpressionKind) -> MdxSignal {
     MdxSignal::Ok
-}
-
-/// Wrap a list of nodes in HTML with the provided start and end fragments
-pub fn wrap_nodes(start: &str, end: &str, nodes: &[Node]) -> String {
-    format!("{}{}{}", start, all_to_html(nodes), end)
-}
-
-/// Convert a list of nodes to HTML
-pub fn all_to_html(nodes: &[Node]) -> String {
-    nodes.iter().fold(String::new(), |acc, child| {
-        format!("{}{}", acc, to_html(child))
-    })
-}
-
-/// Convert a single node to HTML
-pub fn to_html(node: &Node) -> String {
-    match node {
-        Node::Root(root) => root.children.iter().fold(String::new(), |acc, child| {
-            format!("{}{}", acc, to_html(child))
-        }),
-        Node::BlockQuote(block_quote) => wrap_nodes(
-            r#"<blockquote class="blockquote">"#,
-            "</blockquote>",
-            &block_quote.children,
-        ),
-        Node::FootnoteDefinition(_) => "".to_string(),
-        Node::MdxJsxFlowElement(el) => {
-            if let Some(name) = el.name.as_ref() {
-                match apply_component(name, &el.attributes, &el.children) {
-                    Ok(html) => html,
-                    Err(e) => format!("<pre>{}</pre>", html_escape(&e.to_string())),
-                }
-            } else {
-                "".to_string()
-            }
-        }
-        Node::MdxJsxTextElement(el) => {
-            if let Some(name) = el.name.as_ref() {
-                match apply_component(name, &el.attributes, &el.children) {
-                    Ok(html) => html,
-                    Err(e) => format!("<pre>{}</pre>", html_escape(&e.to_string())),
-                }
-            } else {
-                "".to_string()
-            }
-        }
-        Node::List(list) => {
-            if list.ordered {
-                wrap_nodes("<ol>", "</ol>", &list.children)
-            } else {
-                wrap_nodes("<ul>", "</ul>", &list.children)
-            }
-        }
-        Node::MdxjsEsm(_) => "".to_string(),
-        Node::Toml(_) => "".to_string(),
-        Node::Yaml(_) => "".to_string(),
-        Node::Break(_) => "".to_string(),
-        Node::InlineCode(_) => "".to_string(),
-        Node::InlineMath(_) => "".to_string(),
-        Node::Delete(_) => "".to_string(),
-        Node::Emphasis(em) => wrap_nodes(r#"<span class="fst-italic">"#, "</span>", &em.children),
-        Node::MdxTextExpression(_) => "".to_string(),
-        Node::FootnoteReference(_) => "".to_string(),
-        Node::Html(_) => "".to_string(),
-        Node::Image(_) => "".to_string(),
-        Node::ImageReference(_) => "".to_string(),
-        Node::Link(link) => {
-            format!(
-                "<a href=\"{}\">{}</a>",
-                link.url.clone(),
-                all_to_html(link.children.as_slice())
-            )
-        }
-        Node::LinkReference(_) => "".to_string(),
-        Node::Strong(bold) => wrap_nodes(r#"<span class="fw-bold">"#, "</span>", &bold.children),
-        Node::Text(text) => text.value.clone(),
-        Node::Code(code) => {
-            let mut s = String::from("<pre><code>");
-            if let Some(config) = code
-                .lang
-                .as_ref()
-                .and_then(|lang| build_highlighter_config(lang))
-            {
-                let mut highlighter = Highlighter::new();
-                let highlights = highlighter
-                    .highlight(&config, code.value.as_bytes(), None, |_| None)
-                    .unwrap();
-
-                for event in highlights {
-                    match event.unwrap() {
-                        HighlightEvent::Source { start, end } => {
-                            s.push_str(&html_escape(&code.value[start..end]));
-                        }
-                        HighlightEvent::HighlightStart(highlight) => {
-                            s.push_str(&format!("<span class=\"highlight-{}\">", highlight.0));
-                        }
-                        HighlightEvent::HighlightEnd => {
-                            s.push_str("</span>");
-                        }
-                    }
-                }
-            } else {
-                s.push_str(&html_escape(&code.value));
-            }
-            s.push_str("</code></pre>");
-            s
-        }
-        Node::Math(_) => "".to_string(),
-        Node::MdxFlowExpression(exp) => apply_expression(&exp.value).unwrap(),
-        Node::Heading(h) => {
-            let text = heading_text(h).unwrap();
-            let slug = slug(&text);
-            let tag = format!("h{}", h.depth + 3);
-            let html = h.children.iter().fold(String::new(), |acc, child| {
-                format!("{}{}", acc, to_html(child))
-            });
-            format!("<{} id=\"{}\">{}</{}>", tag, slug, html, tag)
-        }
-        Node::Table(table) => wrap_nodes(
-            "<table class=\"table table-sm\">",
-            "</table>",
-            &table.children,
-        ),
-        Node::ThematicBreak(_) => "<hr/>".to_string(),
-        Node::TableRow(node) => wrap_nodes("<tr>", "</tr>", &node.children),
-        Node::TableCell(node) => wrap_nodes("<td>", "</td>", &node.children),
-        Node::ListItem(li) => wrap_nodes("<li>", "</li>", &li.children),
-        Node::Definition(_) => "".to_string(),
-        Node::Paragraph(p) => wrap_nodes("<p>", "</p>", &p.children),
-    }
 }
 
 /// Build a highlighter configuration for the given language
@@ -518,37 +568,5 @@ impl From<&crate::Folder> for SiteMapFolder {
             menu_position: folder.details.menu_position,
             name: folder.get_name(),
         }
-    }
-}
-
-pub fn apply_component(
-    name: &str,
-    attrs: &[markdown::mdast::AttributeContent],
-    children: &[Node],
-) -> Result<String> {
-    let template = match name {
-        "Alert" => crate::assets::get_str("components/alert.html"),
-        "Field" => crate::assets::get_str("components/field.html"),
-        _ => String::default(),
-    };
-
-    let mut data = HashMap::new();
-    for attr in attrs {
-        if let AttributeContent::Property(MdxJsxAttribute {
-            name,
-            value: Some(AttributeValue::Literal(value)),
-        }) = attr
-        {
-            data.insert(name.to_string(), value.to_string());
-        }
-    }
-    data.insert("children".to_string(), all_to_html(children));
-    render_template(data, &template)
-}
-
-pub fn apply_expression(exp: &str) -> Result<String> {
-    match exp {
-        "id" => Ok(nanoid::nanoid!()),
-        _ => Ok("".to_string()),
     }
 }

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -8,8 +8,13 @@ pub struct Error {
 }
 
 impl Error {
-    pub fn new(message: String) -> Self {
-        Self { message }
+    pub fn new<S>(message: S) -> Self
+    where
+        S: Into<String>,
+    {
+        Self {
+            message: message.into(),
+        }
     }
 }
 

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -217,5 +217,11 @@ pub mod tests {
             r#"<p><a href="/docs/somewhere/someplace">Test</a></p>"#,
         );
         assert_eq!(project.details.base_url, "/docs/".to_string());
+
+        let doc = project
+            .get_document_for_url("/docs/elements/external_link")
+            .unwrap();
+
+        assert_eq!(doc.body, r#"<p><a href="https://example.com">Test</a></p>"#,);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,17 +86,20 @@ fn build_project(root_path: String) -> Result<()> {
         let path = pb.strip_prefix("static").unwrap();
 
         if let Some(parent) = path.parent() {
-            if !parent.exists() {
-                std::fs::create_dir_all(parent)?;
-            }
-        }
-        std::fs::write(
-            project
+            let parent_path = project
                 .path
                 .join(project.details.build_path.clone())
-                .join(path),
-            core::assets::get_bytes(&file),
-        )?;
+                .join(parent);
+            if !parent_path.exists() {
+                std::fs::create_dir_all(parent_path)?;
+            }
+        }
+        let file_path = project
+            .path
+            .join(project.details.build_path.clone())
+            .join(path);
+        println!("Writing {}", file_path.display());
+        std::fs::write(file_path, core::assets::get_bytes(&file))?;
     }
 
     Ok(())
@@ -113,7 +116,7 @@ fn build_folder(project: &Project, folder: &core::Folder) -> Result<()> {
 }
 
 fn build_document(path: &Path, project: &Project, doc: &core::Document) -> Result<()> {
-    let content = doc.page_content(project)?;
+    let content = doc.page_content(project, core::ContentMode::Build)?;
     let file_path = if doc
         .file_path
         .file_stem()

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ fn main() {
 
 fn build_project(root_path: String) -> Result<()> {
     let root_path = PathBuf::from(root_path);
-    let project = Project::load(&root_path)?;
+    let project = Project::load(&root_path, false)?;
     let build_path = root_path.join("dist");
     if !build_path.exists() {
         std::fs::create_dir(&build_path)?;
@@ -116,7 +116,7 @@ fn build_folder(project: &Project, folder: &core::Folder) -> Result<()> {
 }
 
 fn build_document(path: &Path, project: &Project, doc: &core::Document) -> Result<()> {
-    let content = doc.page_content(project, core::ContentMode::Build)?;
+    let content = doc.page_content(project)?;
     let file_path = if doc
         .file_path
         .file_stem()

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,4 @@
-use core::{ContentMode, Project};
+use core::Project;
 use std::path::PathBuf;
 
 use tiny_http::{Request, Response, Server};
@@ -21,7 +21,7 @@ pub fn serve(project_path: String) {
     ));
     let server = Server::http(server_url).unwrap();
     let mut handler = ServerHandler {
-        project: Project::load(project_path).unwrap(),
+        project: Project::load(project_path, true).unwrap(),
     };
 
     for request in server.incoming_requests() {
@@ -60,14 +60,11 @@ impl ServerHandler {
             request.url().trim_end_matches('/')
         };
         if let Some(doc) = self.project.get_document_for_url(url) {
-            let response = Response::from_string(
-                doc.page_content(&self.project, ContentMode::Server)
-                    .unwrap(),
-            )
-            .with_header(tiny_http::Header {
-                field: "Content-Type".parse().unwrap(),
-                value: "text/html".parse().unwrap(),
-            });
+            let response = Response::from_string(doc.page_content(&self.project).unwrap())
+                .with_header(tiny_http::Header {
+                    field: "Content-Type".parse().unwrap(),
+                    value: "text/html".parse().unwrap(),
+                });
             let _ = request.respond(response);
         } else {
             let ctx = core::DataContext {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,4 @@
-use core::Project;
+use core::{ContentMode, Project};
 use std::path::PathBuf;
 
 use tiny_http::{Request, Response, Server};
@@ -60,11 +60,14 @@ impl ServerHandler {
             request.url().trim_end_matches('/')
         };
         if let Some(doc) = self.project.get_document_for_url(url) {
-            let response = Response::from_string(doc.page_content(&self.project).unwrap())
-                .with_header(tiny_http::Header {
-                    field: "Content-Type".parse().unwrap(),
-                    value: "text/html".parse().unwrap(),
-                });
+            let response = Response::from_string(
+                doc.page_content(&self.project, ContentMode::Server)
+                    .unwrap(),
+            )
+            .with_header(tiny_http::Header {
+                field: "Content-Type".parse().unwrap(),
+                value: "text/html".parse().unwrap(),
+            });
             let _ = request.respond(response);
         } else {
             let ctx = core::DataContext {

--- a/test/fixture/codex.yml
+++ b/test/fixture/codex.yml
@@ -1,0 +1,3 @@
+name: Testing Project
+repo_url: https://git.example.com
+project_page: https://example.com

--- a/test/fixture/elements/external_link.md
+++ b/test/fixture/elements/external_link.md
@@ -1,0 +1,1 @@
+[Test](https://example.com)

--- a/test/fixture/elements/root_link.md
+++ b/test/fixture/elements/root_link.md
@@ -1,0 +1,1 @@
+[Test](/somewhere/someplace)


### PR DESCRIPTION
# Overview

A base url field was added to the project configuration. When specified this will yield support for the built site to be hosted in a subpath.

## Changes

- Base url was added to the project configuration
- This base URL is prepended to rooted links rendered throughout the page
- The article template uses this base url for static assets
- The URL field on Document is now prepended with the base url if present.
- Serving the site via the CLI ignores the base url

## Justification

Base URLs are common hosting situations including Github Pages.