### PR TITLE
Windows path fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 name: Tests
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,19 @@ jobs:
 
   test:
     name: Test Suite
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macOS-latest
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
+     - name: Checkout sources
+       uses: actions/checkout@v4
 
-      - name: Run tests
-        run: cargo test
+     - name: Run tests
+       run: cargo test
 
   lints:
     name: Lints

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -167,18 +167,24 @@ impl Project {
             } else if path.extension().and_then(|s| s.to_str()) == Some("md") {
                 let mut document = Document::parse_file(self, path.clone())?;
                 document.file_path = path.to_path_buf();
-                if path.file_name().and_then(|s| s.to_str()) == Some("index.md") {
-                    document.url = PathBuf::from(&self.details.base_url)
+                let rel_doc_path = if path.file_name().and_then(|s| s.to_str()) == Some("index.md")
+                {
+                    PathBuf::from(&self.details.base_url)
                         .join(path.parent().unwrap().strip_prefix(&self.path)?)
-                        .display()
-                        .to_string();
                 } else {
-                    document.url = PathBuf::from(&self.details.base_url)
+                    PathBuf::from(&self.details.base_url)
                         .join(path.strip_prefix(&self.path)?)
                         .with_extension("")
-                        .display()
-                        .to_string();
-                }
+                };
+                document.url = format!(
+                    "/{}",
+                    rel_doc_path
+                        .strip_prefix("/")?
+                        .components()
+                        .map(|c| c.as_os_str().to_str().unwrap())
+                        .collect::<Vec<&str>>()
+                        .join("/")
+                );
                 document.base_url = self.details.base_url.clone();
                 folder.documents.push(document);
             }


### PR DESCRIPTION
# Overview

Document urls was being incorrectly calculated on Windows due to path separator 
differences. 

## Changes

Document::url is now built by explitly looping over path components and joining
with '/'. Instead of using PathBuf::join() which uses the platform specific 
separators.

## Justification

Maintaining cross platform compatibility.